### PR TITLE
RD-529_fix-typing-for-npm-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.1",
+  "version": "4.0.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/leaflet-maptilersdk",
-      "version": "4.0.1",
+      "version": "4.0.2-rc.1",
       "dependencies": {
         "@maptiler/sdk": "^3.0.0",
         "leaflet": "^1.9.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/leaflet-maptilersdk",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "@maptiler/sdk": "^3.0.0",
         "leaflet": "^1.9.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Vector tiles basemap plugin for Leaflet - multi-lingual basemaps using MapTiler SDK",
   "module": "dist/leaflet-maptilersdk.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.1",
+  "version": "4.0.2-rc.1",
   "description": "Vector tiles basemap plugin for Leaflet - multi-lingual basemaps using MapTiler SDK",
   "module": "dist/leaflet-maptilersdk.js",
   "type": "module",

--- a/src/leaflet-maptilersdk.ts
+++ b/src/leaflet-maptilersdk.ts
@@ -12,7 +12,7 @@ import {
   Map as MapSDK,
   helpers,
 } from "@maptiler/sdk";
-import packagejson from "../package.json";
+import { name, version } from "../package.json";
 export { Language, MapStyle } from "@maptiler/sdk";
 
 /**
@@ -285,7 +285,7 @@ export const MaptilerLayer = L.Layer.extend({
 
     this._maptilerMap = new MapSDK(options);
 
-    this._maptilerMap.telemetry.registerModule(packagejson.name, packagejson.version);
+    this._maptilerMap.telemetry.registerModule(name, version);
 
     this._maptilerMap.once("load", () => {
       this.fire("ready");

--- a/vite.config-es.ts
+++ b/vite.config-es.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/leaflet-maptilersdk.ts'),
       name: 'leafletmaptilersdk',
-      fileName: () => "leaflet-maptilersdk.min.js",
+      fileName: (format, entryName) => "leaflet-maptilersdk.js",
       formats: ['es'],
     },
     rollupOptions: {

--- a/vite.config-es.ts
+++ b/vite.config-es.ts
@@ -28,6 +28,9 @@ export default defineConfig({
     },
   },
   plugins: [
-    dts({insertTypesEntry: true}),
+    dts({
+      insertTypesEntry: true,
+      entryRoot: "src",
+    }),
   ],
 });


### PR DESCRIPTION
## Objective
To fix typescript declarations

## Description
File name of the ES release is not match the package.json exports declarations

## Acceptance
Tested by creating a Vite app and installing the release candidate.

## Checklist
- [ ] I have added relevant info to the CHANGELOG.md