### PR TITLE
fix(package): move @types/leaflet to `dependencies` instead of `devDependencies`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # MapTiler Client Changelog
 
+## 4.0.3
+- Move @leaflet/types to dependencies to ensure they're included when project is installed.
 
 ## 4.0.2
 - Fix ES release to use correct declarations

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/leaflet-maptilersdk",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "dependencies": {
         "@maptiler/sdk": "^3.0.0",
         "leaflet": "^1.9.4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "license": "",
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@types/leaflet": "^1.9.16",
     "@types/node": "^22.10.5",
     "concurrently": "^9.1.2",
     "typescript": "^5.7.2",
@@ -45,6 +44,7 @@
     "vite-plugin-dts": "^4.4.0"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.16",
     "@maptiler/sdk": "^3.0.0",
     "leaflet": "^1.9.4"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/leaflet-maptilersdk",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Vector tiles basemap plugin for Leaflet - multi-lingual basemaps using MapTiler SDK",
   "module": "dist/leaflet-maptilersdk.js",
   "type": "module",


### PR DESCRIPTION
## Objective
Make Leaflet types available in @maptiler/leaflet-maptilersdk

## Description
Moved `@types/leaflet` to dependencies instead of devDepencies

## Acceptance
Manual testing in a separate project.

## Checklist
- [x] I have added relevant info to the CHANGELOG.md